### PR TITLE
Added support for using 'default' as a response code in swagger

### DIFF
--- a/test/controllers/validation.js
+++ b/test/controllers/validation.js
@@ -38,6 +38,10 @@ exports.invalidResponse = (req, res) => res.send(invalid);
 exports.invalidResponseMocked = (req, res) => res.send(invalid);
 exports.invalidResponseMocked.mock = (req, res) => res.send(invalid);
 
+exports.invalidResponseCode = (req, res) => {
+    res.status(500).send({ code: 500, message: 'Oops' });
+};
+
 exports.defaultResponse = (req, res) => {
     res.status(500).send({ code: 500, message: 'Oops' });
 };

--- a/test/swagger/validation.yaml
+++ b/test/swagger/validation.yaml
@@ -78,7 +78,19 @@ paths:
           description: Error
           schema:
             $ref: '#/definitions/Error'
-
+  "/invalid-response-code":
+      get:
+        operationId: invalidResponseCode
+        responses:
+          '200':
+            description: Response
+            examples:
+              application/json:
+              - id: 123
+                name: Sparky
+                tag: Dog
+            schema:
+              "$ref": "#/definitions/Pets"
   "/default-response":
     get:
       operationId: defaultResponse

--- a/test/validation.js
+++ b/test/validation.js
@@ -64,11 +64,10 @@ describe('validation', () => {
     });
 
     it('exception', () => {
-        return api.request('/v1/default-response')
+        return api.request('/v1/invalid-response-code')
             .then(res => {
                 expect(res.body).to.equal(JSON.stringify({ code: 500, message: 'Invalid swagger response code: 500' }));
             });
-
     });
 
     describe('valid response', () => {
@@ -87,6 +86,13 @@ describe('validation', () => {
                 .then(res => {
                     expect(res.body).to.equal(validExample);
                 });
+        });
+
+        it('default response', () => {
+          return api.request('/v1/default-response')
+            .then(res => {
+              expect(res.body).to.equal(JSON.stringify({ code: 500, message: 'Oops' }));
+            });
         });
 
     });


### PR DESCRIPTION
The current implementation considers sending 500s with a body that matches the schema defined in a swagger response under `default` to be an error due to an `invalid swagger response code` (assuming 500 isn't an explicitly defined response code).

This pull request aims to allow responses to succeed if they match the schema specified under `default` (if provided).

For reference, see the **Default Response** section at https://swagger.io/docs/specification/2-0/describing-responses/ .

It would, of course, need a new version for npm, etc.